### PR TITLE
Remove octals

### DIFF
--- a/lib/ansi.js
+++ b/lib/ansi.js
@@ -12,7 +12,7 @@
  */
 
 var emitNewlineEvents = require('./newlines')
-  , prefix = '\033[' // For all escape codes
+  , prefix = '\x1b[' // For all escape codes
   , suffix = 'm'     // Only for color codes
 
 /**
@@ -274,7 +274,7 @@ Object.keys(colors).forEach(function (color) {
  */
 
 Cursor.prototype.beep = function () {
-  this.enabled && this.write('\007')
+  this.enabled && this.write('\x07')
   return this
 }
 


### PR DESCRIPTION
Octals are deprecated in ECMA 5 so we should use hexadecimal notation
instead.
