### PR TITLE
Preserve chaining after redundant style-method calls.

### DIFF
--- a/lib/ansi.js
+++ b/lib/ansi.js
@@ -238,14 +238,14 @@ Object.keys(styles).forEach(function (style) {
     , r = reset[style]
 
   Cursor.prototype[style] = function () {
-    if (this[name]) return
+    if (this[name]) return this
     this.enabled && this.write(prefix + c + suffix)
     this[name] = true
     return this
   }
 
   Cursor.prototype['reset' + name] = function () {
-    if (!this[name]) return
+    if (!this[name]) return this
     this.enabled && this.write(prefix + r + suffix)
     this[name] = false
     return this


### PR DESCRIPTION
The style methods on the Cursor class do not return an instance of the class when they are already enabled. For instance, `cursor.bold().italic()` will throw a TypeError if the cursor is already bold because `bold()` returns `undefined`, thus breaking the chaining.

This commit fixes that issue by always making calls to bold/italic/underline/inverse return an instance of Cursor.
